### PR TITLE
[WIP]READMEを修正しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,22 @@
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user|text|null: false|
+|name|string|null: false|
 |email|text|null: false, unique|
 |password|text|null: false|
 
 ### Association
-- なし
+- hasmany_to :groups
+- hasmany_to :messages
+- hasmany_to :imgs
+
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|text|null: false|
+|name|string|null: false|
+
 ### Association
-- なし
+- hasmany_to :groups
 
 ## group_usersテーブル（グループに誰が所属しているか）
 |Column|Type|Options|
@@ -22,39 +26,12 @@
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 - belongs_to :group
-- hasmany_to :users
-
-## user_belongs_groupsテーブル（ユーザーがどんなグループに入っているか）
-|Column|Type|Options|
-|------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
-### Association
-- belongs_to :user
-- hasmany_to :groups
-
-## group_mastarsテーブル(グループを誰が作ったか)
-|Column|Type|Options|
-|------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
-
-### Association
-- hasmany_to :groups
 - belongs_to :user
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |text|string|null: false|
-
-### Association
-- なし
-
-## group_messagesテーブル
-|Column|Type|Options|
-|------|----|-------|
-|messages_id|integer|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
@@ -67,14 +44,6 @@
 |Column|Type|Options|
 |------|----|-------|
 |img|string|null: false, unique|
-
-### Association
-- なし
-
-## group_imgsテーブル
-|Column|Type|Options|
-|------|----|-------|
-|img|string|null: false, unique|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
@@ -82,18 +51,6 @@
 - belongs_to :group
 - hasmany_to :users
 - hasmany_to :imgs
-
-## user_messegeテーブル(インデックス、メッセージ内容管理用)
-|Column|Type|Options|
-|------|----|-------|
-|user_name|integer|null: false, foreign_key: true|
-|group_name|integer|null: false, foreign_key: true|
-|message_text|integer|null: false, foreign_key: true|
-
-### Association
-- belongs_to :group
-- belongs_to :user
-
 
 
 # 機能洗い出しメモ

--- a/README.md
+++ b/README.md
@@ -8,39 +8,70 @@
 |password|text|null: false|
 
 ### Association
-- hasmany_to :groups
-- hasmany_to :messages
-- hasmany_to :imgs
-
+- なし
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |name|text|null: false|
-- hasmany_to :messages
-- hasmany_to :imgs
+### Association
+- なし
 
-## group_mastarsテーブル(グループ作成者のフラグ管理)
+## group_usersテーブル（グループに誰が所属しているか）
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+- belongs_to :group
+- hasmany_to :users
+
+## user_belongs_groupsテーブル（ユーザーがどんなグループに入っているか）
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- hasmany_to :groups
+
+## group_mastarsテーブル(グループを誰が作ったか)
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :group
+- hasmany_to :groups
 - belongs_to :user
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |text|string|null: false|
+
+### Association
+- なし
+
+## group_messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|messages_id|integer|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
-- belongs_to :user
+- hasmany_to :user
+- hasmany_to :messages
 
 ## imgsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|img|string|null: false, unique|
+
+### Association
+- なし
+
+## group_imgsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |img|string|null: false, unique|
@@ -49,9 +80,10 @@
 
 ### Association
 - belongs_to :group
-- belongs_to :user
+- hasmany_to :users
+- hasmany_to :imgs
 
-## user_messegeテーブル(インデックス)
+## user_messegeテーブル(インデックス、メッセージ内容管理用)
 |Column|Type|Options|
 |------|----|-------|
 |user_name|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 |password|text|null: false|
 
 ### Association
-- hasmany_to :groups
-- hasmany_to :messages
-- hasmany_to :imgs
+- has_many :groups, through: :group_users
+- has_many :group_users
+- has_many :messages
 
 ## groupsテーブル
 |Column|Type|Options|
@@ -18,8 +18,9 @@
 |name|string|null: false|
 
 ### Association
-- hasmany_to :users
-- hasmany_to :messages
+- has_many :users, through: :group_users
+- has_many :group_users
+- has_many :messages
 
 ## group_usersテーブル（グループに誰が所属しているか）
 |Column|Type|Options|
@@ -41,9 +42,7 @@
 
 ### Association
 - belongs_to :group
-- hasmany_to :user
-- hasmany_to :messages
-- hasmany_to :img
+- belongs_to :user
 
 # 機能洗い出しメモ
 ## ログイン

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false|
+|name|string|null: false,index: true|
 |email|text|null: false, unique|
 |password|text|null: false|
 
@@ -15,7 +15,7 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false|
+|name|string|null: false,index: true|
 
 ### Association
 - has_many :users, through: :group_users
@@ -25,8 +25,8 @@
 ## group_usersテーブル（グループに誰が所属しているか）
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -35,10 +35,10 @@
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|string|null: default|
-|img|string|null: default|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|text|text||
+|img|string||
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -18,20 +18,24 @@
 |name|string|null: false|
 
 ### Association
-- hasmany_to :groups
+- hasmany_to :users
+- hasmany_to :messages
 
 ## group_usersテーブル（グループに誰が所属しているか）
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
+
+### Association
 - belongs_to :group
 - belongs_to :user
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|string|null: false|
+|text|string|null: default|
+|img|string|null: default|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
@@ -39,19 +43,7 @@
 - belongs_to :group
 - hasmany_to :user
 - hasmany_to :messages
-
-## imgsテーブル
-|Column|Type|Options|
-|------|----|-------|
-|img|string|null: false, unique|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
-
-### Association
-- belongs_to :group
-- hasmany_to :users
-- hasmany_to :imgs
-
+- hasmany_to :img
 
 # 機能洗い出しメモ
 ## ログイン
@@ -117,9 +109,9 @@
 - メッセージがチャット画面に表示される（リアルタイム）
 - サイドバーの最新のチャット1件が表示更新される（リアルタイムでない）
 - URLはクリッカブルにならない←なったほうが便利なのでメモ
-- 画像の送信が遅かったらテキストなどが優先される（早く送れるほうを優先する）
+- 画像の送信が遅かったらテキストなどが優先される（早く送れるほうを優先する？）早すぎてわからん
 - 画像が送られたら最新コメントに「画像が投稿されました」←ここは分岐でdb使わない
-- 画像投稿コメントとは紐づかない
+- 画像投稿コメントとは紐づかない×　ひもづく←アイコンに選択してる感がない逮捕
 - お話中のキックされてもそのチャットルームに残る、更新されるといなくなる（グループ内のユーザー管理はリアルタイムでない）
 - キックしてもチャット履歴は残る（ユーザーがいなくなっても、投稿されたコメントはなくならない）
 - キックされた人の履歴の名前も更新される(つまりグループから抜けてもメッセージとコメントは紐づいてる)


### PR DESCRIPTION
#What
下記のテーブルを追加しました。
・group_users
・user_belongs_groups
・group_messages
・group_imgs

#Why
多対多の関係性について見直し、上記の4つのテーブルを追加しました。
・group_users
　→グループのメンバーに誰が属しているか
・user_belongs_groups
　→ユーザーは幾つのグループを掛け持ちしているか
・group_messages
　→グループは誰のメッセージを保持しているか
・group_imgs
　→グループは誰の画像を保持しているか

実機確認し、仕様としてグループを抜けても、そのユーザーの情報は残り、プロフィール変更なども更新されたため、messagesやimgsはgroup_usersに紐付けない。